### PR TITLE
Update README.md as per 1.16.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ KSPTOT contains the following software tools:
 8.  To update from a previous version, just repeat steps 3-6. There is no need to re-download the MCR.
 #### **Mac/Linux Users: Follow these instructions instead.**
 1.  (Mac only): [Download VirtualBox for OS X hosts.](https://www.virtualbox.org/wiki/Downloads) Install according to the VirtualBox instructions. Setup and install a distribution of Linux as a virtual machine within VirtualBox. (Ex: [Ubuntu](https://www.ubuntu.com/download/desktop)) All instructions from here on down will reference the virtual machine and it's Linux operating system, not the Mac system.
-2.  Download the [Linux 64-bit 2022a MATLAB Compiler Runtime (MCR).](https://www.mathworks.com/products/compiler/matlab-runtime.html)
+2.  Download the [Linux 64-bit R2023b MATLAB Compiler Runtime (MCR).](https://www.mathworks.com/products/compiler/matlab-runtime.html)
 3.  Install the MCR package on your computer. **You may need to restart your PC after installing in order to use KSPTOT.**
-    1.  You MUST install the MCR to **"/usr/local/MATLAB/R2022a/"!** The software will not work correctly if this is not done.
+    1.  You MUST install the MCR to **"/usr/local/MATLAB/R2023b/"!** The software will not work correctly if this is not done.
 4.  **Download the KSPTOT Package.**
 5.  Unzip the KSPTOT package to a directory of your choosing.
 6.  Set the execution bit on the run script and the executable itself. Using the following console command:
     1.  _chmod +x run_KSPTrajectoryOptimizationTool.sh KSPTrajectoryOptimizationTool_
 7.  **Copy the KSPTOTConnect folder to your KSP Gamedata folder**.
 8.  **Copy the Ships folder to your KSP folder** (if you use kOS).
-9.  From within the directory where you unpacked KSPTOT, run "**./run_KSPTrajectoryOptimizationTool.sh /usr/local/MATLAB/R2022a/**" to launch KSPTOT.
+9.  From within the directory where you unpacked KSPTOT, run "**./run_KSPTrajectoryOptimizationTool.sh /usr/local/MATLAB/R2023b/**" to launch KSPTOT.
 10.  To update from a previous version, just repeat steps 4-6. There is no need to re-download the MCR.
 11.  For addition detail, see [here](https://finitemonkeys.org/ksptot_on_linux).  
 ## Buy Me a Coffee

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ KSPTOT contains the following software tools:
 
 ## Download & Installation Instructions
 #### To install and run KSPTOT on **Windows**, do the following:
-1.  Download the [Windows 64-bit 2022a MATLAB Compiler Runtime (MCR)](https://www.mathworks.com/products/compiler/matlab-runtime.html).
+1.  Download the [Windows 64-bit R2023b MATLAB Compiler Runtime (MCR)](https://www.mathworks.com/products/compiler/matlab-runtime.html).
 2.  Install the MCR package on your computer. **You may need to restart your PC after installing in order to use KSPTOT.**
 3.  **Download the KSPTOT package.
 4.  Unzip the KSPTOT package to a directory of your choosing.


### PR DESCRIPTION
> NOTE: If you are upgrading from KSPTOT v1.6.9 or earlier, you MUST download the R2023b MATLAB Compiler Runtime (MCR)! KSPTOT v1.6.10 will not run without this! You can find the R2023b MCR download for your platform here: https://www.mathworks.com/products/compiler/matlab-runtime.html